### PR TITLE
feat: add ignore syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-mobx-observer-on-every-react-component",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Wrap literally every React component in an MobX observer higher order component.",
   "keywords": [
     "babel-plugin",

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,17 @@ Here are some options we'll eventually add:
 
 ### Ignore files/lines
 
-**Coming soon**: eventually we'll have a syntax to ignore entire files or lines of code if you prefer to opt-out of plugin transformation.
+If you want to ignore an entire file, add a comment to the top of the file:
+
+```ts
+// @auto-observer-ignore-file
+```
+
+If you want to ignore a specific block, add a comment to the start of the block:
+
+```ts
+// @auto-observer-ignore-block
+```
 
 ## Examples
 

--- a/src/__snapshots__/ignoreComments.test.js.snap
+++ b/src/__snapshots__/ignoreComments.test.js.snap
@@ -1,0 +1,46 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Mobx Observer Babel Plugin ignoreComments when the comment is to ignore the full file ignores everything in the file 1`] = `
+"// @auto-observer-ignore-file
+class MyComponentClassDeclaration {
+  render() {
+    return /*#__PURE__*/React.createElement("div", null, "Hello World");
+  }
+}
+const MyArrowObserver = () => /*#__PURE__*/React.createElement("div", null, "Hello World");
+const MyComponentClassExpression = class MyComponent {
+  render() {
+    return /*#__PURE__*/React.createElement("div", null, "Hello World");
+  }
+};
+function MyComponentDeclaration() {
+  return /*#__PURE__*/React.createElement("div", null, "Hello World");
+}
+const MyComponentExpression = function MyComponentExpression() {
+  return /*#__PURE__*/React.createElement("div", null, "Hello World");
+};"
+`;
+
+exports[`Mobx Observer Babel Plugin ignoreComments when the comment is to ignore a specific block ignores the specific block 1`] = `
+"import { observer } from "mobx-react";
+// @auto-observer-ignore-block
+class MyComponentClassDeclaration {
+  render() {
+    return /*#__PURE__*/React.createElement("div", null, "Hello World");
+  }
+}
+const MyArrowObserver = observer(() => /*#__PURE__*/React.createElement("div", null, "Hello World"));
+const MyComponentClassExpression = observer(class MyComponent {
+  render() {
+    return /*#__PURE__*/React.createElement("div", null, "Hello World");
+  }
+});
+function MyComponentDeclaration() {
+  return observer(function MyComponentDeclaration() {
+    return /*#__PURE__*/React.createElement("div", null, "Hello World");
+  });
+}
+const MyComponentExpression = observer(function MyComponentExpression() {
+  return /*#__PURE__*/React.createElement("div", null, "Hello World");
+});"
+`;

--- a/src/ignoreComments.test.js
+++ b/src/ignoreComments.test.js
@@ -1,0 +1,54 @@
+import { expect, test, describe } from "bun:test";
+import { transform } from "@babel/core";
+import pluginSyntaxJsx from "@babel/plugin-syntax-jsx";
+import pluginTransReactJsx from "@babel/plugin-transform-react-jsx";
+import pluginSyntaxDecorators from "@babel/plugin-syntax-decorators";
+import pluginSyntaxDecoratorsLegacy from "@babel/plugin-proposal-decorators";
+import autoObserverPlugin from "./index.ts";
+
+const runTransform = (input) => {
+    return transform(input, {
+        plugins: [pluginSyntaxJsx, pluginTransReactJsx, [pluginSyntaxDecorators, { version: "2018-09", decoratorsBeforeExport: false }], autoObserverPlugin],
+    });
+};
+
+const runTransformLegacy = (input) => {
+    return transform(input, {
+        plugins: [pluginSyntaxJsx, pluginTransReactJsx, [pluginSyntaxDecoratorsLegacy, { legacy: true }], autoObserverPlugin],
+    });
+};
+
+describe("Mobx Observer Babel Plugin", () => {
+    describe("ignoreComments", () => {
+        describe("when the comment is to ignore the full file", () => {
+            test("ignores everything in the file", () => {
+                const source = `
+          // @auto-observer-ignore-file
+          class MyComponentClassDeclaration { render() { return <div>Hello World</div>; } }
+          const MyArrowObserver = () => <div>Hello World</div>
+          const MyComponentClassExpression = class MyComponent { render() { return <div>Hello World</div>; } }
+          function MyComponentDeclaration() { return <div>Hello World</div>; }
+          const MyComponentExpression = function MyComponentExpression() { return <div>Hello World</div>; }
+          `;
+                const out = runTransform(source);
+
+                expect(out.code).toMatchSnapshot();
+            });
+        });
+        describe("when the comment is to ignore a specific block", () => {
+            test("ignores the specific block", () => {
+                const source = `
+        // @auto-observer-ignore-block
+        class MyComponentClassDeclaration { render() { return <div>Hello World</div>; } }
+        const MyArrowObserver = () => <div>Hello World</div>
+        const MyComponentClassExpression = class MyComponent { render() { return <div>Hello World</div>; } }
+        function MyComponentDeclaration() { return <div>Hello World</div>; }
+        const MyComponentExpression = function MyComponentExpression() { return <div>Hello World</div>; }
+        `;
+                const out = runTransform(source);
+
+                expect(out.code).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { PluginPass } from '@babel/core';
  */
 interface PluginOptions {
   // Default false, controls if we log debug statements during plugin execution. Mostly intended for plugin developers.
-  debugEnabled?: boolean; 
+  debugEnabled?: boolean;
 }
 
 type BabelTypes = typeof import('@babel/types');
@@ -18,6 +18,8 @@ export default declare((api, options?: PluginOptions ) => {
   const debugEnabled = options?.debugEnabled ?? false;
   const t = api.types;
   let ignoreFile = false;
+
+
 
   return {
     name: "babel-plugin-mobx-observer-on-every-react-component",
@@ -100,7 +102,7 @@ export default declare((api, options?: PluginOptions ) => {
       },
 
       ArrowFunctionExpression(path, state) {
-        if (isInNodeModules(state) || ignoreFile) {
+        if (isInNodeModules(state) || ignoreFile || shouldIgnoreBlock(path)) {
           return;
         }
 
@@ -128,7 +130,7 @@ export default declare((api, options?: PluginOptions ) => {
         }
       },
       ClassDeclaration(path, state) {
-        if (isInNodeModules(state) || ignoreFile) {
+        if (isInNodeModules(state) || ignoreFile || shouldIgnoreBlock(path)) {
           return;
         }
 
@@ -168,7 +170,7 @@ export default declare((api, options?: PluginOptions ) => {
         }
       },
       ClassExpression(path, state) {
-        if (isInNodeModules(state) || ignoreFile) {
+        if (isInNodeModules(state) || ignoreFile || shouldIgnoreBlock(path)) {
           return;
         }
 
@@ -201,7 +203,7 @@ export default declare((api, options?: PluginOptions ) => {
         }
       },
       FunctionDeclaration(path, state) {
-        if (isInNodeModules(state) || ignoreFile) {
+        if (isInNodeModules(state) || ignoreFile || shouldIgnoreBlock(path)) {
           return;
         }
 
@@ -256,7 +258,7 @@ export default declare((api, options?: PluginOptions ) => {
         }
       },
       FunctionExpression(path, state) {
-        if (isInNodeModules(state) || ignoreFile) {
+        if (isInNodeModules(state) || ignoreFile || shouldIgnoreBlock(path)) {
           return;
         }
 
@@ -426,6 +428,11 @@ function classHasRenderMethod(path: NodePath<t.ClassDeclaration | t.ClassExpress
   }
 
   return false;
+}
+
+function shouldIgnoreBlock(path: NodePath): boolean {
+  const comments = path.node.leadingComments || [];
+  return comments.some(comment => comment.value.trim() === '@auto-observer-ignore-block');
 }
 
 function debug(message: string, debugEnabled: boolean): void {


### PR DESCRIPTION
## What does this PR do and why?

This PR adds ignore syntax for two cases: 

1. [x] Ignore entire files with `// @auto-observer-ignore-file`
2. [x] Ignore specific blocks of code with `// @auto-observer-ignore-block`

## Steps to validate locally

Check out the tests in `src/ignoreComments.test.js` and see that they operate as you'd expect. Play around with the new changes in the example repo as well.