### PR TITLE
fix: default export function declarations, Vite HMR not working

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css'
 import { makeAutoObservable } from "mobx";
 import FunctionDeclaration from "./FunctionDeclaration";
+import DefaultExportFunctionDeclaration from "./DefaultExportFunctionDeclaration";
 
 class CounterStore {
   count = 0;
@@ -28,6 +29,7 @@ const App = function App() {
         <button onClick={() => counterStore.increment()}>Increment</button>
         <button onClick={() => counterStore.decrement()}>Decrement</button>
         <FunctionDeclaration />
+        <DefaultExportFunctionDeclaration />
       </div>
     </>
   )

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css'
 import { makeAutoObservable } from "mobx";
 import FunctionDeclaration from "./FunctionDeclaration";
 import DefaultExportFunctionDeclaration from "./DefaultExportFunctionDeclaration";
+import { NamedExportFunctionDeclaration } from "./NamedExportFunctionDeclaration";
 
 class CounterStore {
   count = 0;
@@ -30,6 +31,7 @@ const App = function App() {
         <button onClick={() => counterStore.decrement()}>Decrement</button>
         <FunctionDeclaration />
         <DefaultExportFunctionDeclaration />
+        <NamedExportFunctionDeclaration />
       </div>
     </>
   )

--- a/example/src/DefaultExportFunctionDeclaration.tsx
+++ b/example/src/DefaultExportFunctionDeclaration.tsx
@@ -1,0 +1,9 @@
+export default function DefaultExportFunctionDeclaration() {
+
+  return (
+    <div>
+        This is a function declaration but it's a default export
+    </div>
+  )
+}
+

--- a/example/src/NamedExportFunctionDeclaration.tsx
+++ b/example/src/NamedExportFunctionDeclaration.tsx
@@ -1,0 +1,10 @@
+export function NamedExportFunctionDeclaration() {
+    return (
+      <div>
+        <h1>Named Export Function Declaration Component</h1>
+        <p>This is an example of a React component using a named export function declaration.</p>
+      </div>
+    );
+}
+
+

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -3,8 +3,10 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    hmr: false
+  },
   plugins: [
-    
     react({
     babel: {
       plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-mobx-observer-on-every-react-component",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Wrap literally every React component in an MobX observer higher order component.",
   "keywords": [
     "babel-plugin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,8 +245,16 @@ export default declare((api, options?: PluginOptions ) => {
             t.variableDeclarator(functionId, observerFunction)
           ]);
 
-            path.replaceWith(variableDeclaration);
+          // now check to see if the function declaration is exported. If it is, we need to replace
+          // the functione with the observer-wrapped function and then export it
+          // If it's not exported, we can just replace the functoin with the variable declaration
+          if (path.parentPath.isExportDefaultDeclaration()) {
+            path.parentPath.replaceWith(t.exportDefaultDeclaration(observerFunction));
           } else {
+            path.replaceWith(variableDeclaration);
+          }
+
+        } else {
             // Replace the old function declaration with the new variable declaration
             path.replaceWith(observerFunction);
           }


### PR DESCRIPTION
## What does this PR do and why?

Two separate fixes: 

1. If a function declaration is a default export, don't just replace it with the variable expression. Rather, use the observer expression.
2. I figured out that Vite HMR is trying to hang on to the function declaration name when it ought not to. That's a separate problem, but for now turning off HMR lets this fix actually take hold.

## Steps to validate locally

Tests pass, new example site works, although HMR will no longer work